### PR TITLE
fix MetricRegistryManager rotation issue

### DIFF
--- a/src/main/java/io/reign/metrics/RotatingMetricRegistryManager.java
+++ b/src/main/java/io/reign/metrics/RotatingMetricRegistryManager.java
@@ -13,18 +13,6 @@
 
 package io.reign.metrics;
 
-import io.reign.util.TimeUnitUtil;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
@@ -32,6 +20,17 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import io.reign.util.TimeUnitUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 
@@ -173,7 +172,7 @@ public class RotatingMetricRegistryManager implements MetricRegistryManager {
 
 			// reset metrics
 			Map<String, Metric> metricMap = this.metricRegistry.getMetrics();
-			Set<String> keys = metricMap.keySet();
+			Set<String> keys = new HashSet<String>(metricMap.keySet());
 			for (String key : keys) {
 				String metricName = key;
 				Metric metric = metricMap.get(metricName);


### PR DESCRIPTION
The issue happens in Java 8 because of changes to Map.keySet(). The for loop was modifying the MetricRegistry's underlying map of metrics, which would cause the for loop to iterate over the same element twice, which then caused an exception inside the loop and stopped the MetricRegistryManager from rotating altogether.

The fix was to iterate over a brand new set rather than the map's keySet. I've already tested it locally and didn't have any errors on rotation.